### PR TITLE
Implement enhanced build distribution system with universal binary support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,71 @@ A lightweight, native macOS auto-clicker application with precision timing and a
 
 This project is organized into milestones tracking the development progress. Check the Issues tab for current development tasks and project roadmap.
 
+### Building from Source
+
+#### Prerequisites
+- Xcode 15.0 or later
+- Swift 5.9 or later
+- macOS 15.0 or later
+
+#### Quick Start
+```bash
+# Clone the repository
+git clone https://github.com/jsonify/clickit.git
+cd clickit
+
+# Build and run for development
+swift run
+
+# Or build the app bundle
+./build_app.sh
+```
+
+#### Build Commands
+
+**Development Build:**
+```bash
+# Build for current architecture (debug)
+swift build
+
+# Run directly
+swift run
+```
+
+**Distribution Build:**
+```bash
+# Create universal app bundle (Intel + Apple Silicon)
+./build_app.sh
+
+# Create debug app bundle
+./build_app.sh debug
+
+# Launch the built app
+open dist/ClickIt.app
+```
+
+#### Build Output Structure
+- `dist/ClickIt.app` - Final app bundle
+- `dist/binaries/` - Individual architecture binaries
+- `dist/build-info.txt` - Build metadata
+- `.build/` - Swift Package Manager build cache
+
+#### Universal Binary Support
+The build system automatically detects available architectures and creates universal binaries when possible:
+- **Intel x64**: `x86_64-apple-macosx`
+- **Apple Silicon**: `arm64-apple-macosx`
+- **Universal**: Combined binary supporting both architectures
+
+#### Testing
+```bash
+# Run unit tests
+swift test
+
+# Build and test specific configuration
+swift build -c release
+swift test -c release
+```
+
 ## Contributing
 
 Contributions are welcome! Please read our contributing guidelines and check the Issues tab for open tasks.

--- a/build_app.sh
+++ b/build_app.sh
@@ -39,9 +39,7 @@ echo "📱 Building for architectures: ${ARCH_LIST[*]}"
 BINARY_PATHS=()
 for arch in "${ARCH_LIST[@]}"; do
     echo "⚙️  Building for $arch..."
-    swift build -c "$BUILD_MODE" --arch "$arch"
-    
-    if [ $? -ne 0 ]; then
+    if ! swift build -c "$BUILD_MODE" --arch "$arch"; then
         echo "❌ Build failed for $arch"
         exit 1
     fi

--- a/build_app.sh
+++ b/build_app.sh
@@ -1,47 +1,109 @@
 #!/bin/bash
 
-# Build ClickIt as a proper macOS app bundle
+set -e  # Exit on any error
 
-echo "Building ClickIt app bundle..."
+# Build ClickIt as a proper macOS app bundle with universal binary support
+
+BUILD_MODE="${1:-release}"  # Default to release, allow override
+DIST_DIR="dist"
+APP_NAME="ClickIt"
+BUNDLE_ID="com.jsonify.clickit"
+VERSION="1.0.0"
+
+echo "🔨 Building $APP_NAME app bundle ($BUILD_MODE mode)..."
 
 # Clean previous builds
-rm -rf ClickIt.app
+echo "🧹 Cleaning previous builds..."
+rm -rf "$DIST_DIR/$APP_NAME.app"
+rm -rf "$DIST_DIR/binaries"
+mkdir -p "$DIST_DIR/binaries"
 
-# Build the executable
-swift build -c release
+# Detect available architectures
+echo "🔍 Detecting available architectures..."
+ARCH_LIST=()
+if swift build -c "$BUILD_MODE" --arch x86_64 --show-bin-path > /dev/null 2>&1; then
+    ARCH_LIST+=("x86_64")
+fi
+if swift build -c "$BUILD_MODE" --arch arm64 --show-bin-path > /dev/null 2>&1; then
+    ARCH_LIST+=("arm64")
+fi
 
-if [ $? -ne 0 ]; then
-    echo "Build failed"
+if [ ${#ARCH_LIST[@]} -eq 0 ]; then
+    echo "❌ No supported architectures found"
     exit 1
 fi
 
+echo "📱 Building for architectures: ${ARCH_LIST[*]}"
+
+# Build for each architecture
+BINARY_PATHS=()
+for arch in "${ARCH_LIST[@]}"; do
+    echo "⚙️  Building for $arch..."
+    swift build -c "$BUILD_MODE" --arch "$arch"
+    
+    if [ $? -ne 0 ]; then
+        echo "❌ Build failed for $arch"
+        exit 1
+    fi
+    
+    # Get the actual build path
+    BUILD_PATH=$(swift build -c "$BUILD_MODE" --arch "$arch" --show-bin-path)
+    BINARY_PATH="$BUILD_PATH/$APP_NAME"
+    
+    if [ ! -f "$BINARY_PATH" ]; then
+        echo "❌ Binary not found at $BINARY_PATH"
+        exit 1
+    fi
+    
+    # Copy binary to dist directory
+    cp "$BINARY_PATH" "$DIST_DIR/binaries/$APP_NAME-$arch"
+    BINARY_PATHS+=("$DIST_DIR/binaries/$APP_NAME-$arch")
+done
+
+# Create universal binary if multiple architectures
+if [ ${#BINARY_PATHS[@]} -gt 1 ]; then
+    echo "🔗 Creating universal binary..."
+    lipo -create -output "$DIST_DIR/binaries/$APP_NAME-universal" "${BINARY_PATHS[@]}"
+    FINAL_BINARY="$DIST_DIR/binaries/$APP_NAME-universal"
+else
+    echo "📦 Using single architecture binary..."
+    FINAL_BINARY="${BINARY_PATHS[0]}"
+fi
+
+# Verify binary
+echo "🔍 Verifying binary architectures..."
+file "$FINAL_BINARY"
+lipo -info "$FINAL_BINARY" 2>/dev/null || echo "Single architecture binary"
+
 # Create app bundle structure
-mkdir -p ClickIt.app/Contents/MacOS
-mkdir -p ClickIt.app/Contents/Resources
+echo "📁 Creating app bundle structure..."
+APP_BUNDLE="$DIST_DIR/$APP_NAME.app"
+mkdir -p "$APP_BUNDLE/Contents/MacOS"
+mkdir -p "$APP_BUNDLE/Contents/Resources"
 
 # Copy executable
-cp .build/x86_64-apple-macosx/release/ClickIt ClickIt.app/Contents/MacOS/
+cp "$FINAL_BINARY" "$APP_BUNDLE/Contents/MacOS/$APP_NAME"
 
 # Create Info.plist
-cat > ClickIt.app/Contents/Info.plist << 'EOF'
+cat > "$APP_BUNDLE/Contents/Info.plist" << EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>CFBundleDisplayName</key>
-    <string>ClickIt</string>
+    <string>$APP_NAME</string>
     <key>CFBundleExecutable</key>
-    <string>ClickIt</string>
+    <string>$APP_NAME</string>
     <key>CFBundleIdentifier</key>
-    <string>com.jsonify.clickit</string>
+    <string>$BUNDLE_ID</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleName</key>
-    <string>ClickIt</string>
+    <string>$APP_NAME</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.0.0</string>
+    <string>$VERSION</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>LSMinimumSystemVersion</key>
@@ -57,8 +119,21 @@ cat > ClickIt.app/Contents/Info.plist << 'EOF'
 EOF
 
 # Make executable
-chmod +x ClickIt.app/Contents/MacOS/ClickIt
+chmod +x "$APP_BUNDLE/Contents/MacOS/$APP_NAME"
 
-echo "✅ ClickIt.app created successfully!"
-echo "📱 Launch with: open ClickIt.app"
+# Create build metadata
+echo "📋 Creating build metadata..."
+cat > "$DIST_DIR/build-info.txt" << EOF
+Build Date: $(date)
+Mode: $BUILD_MODE
+Architectures: ${ARCH_LIST[*]}
+Binary Type: $([ ${#BINARY_PATHS[@]} -gt 1 ] && echo "Universal" || echo "Single Architecture")
+Version: $VERSION
+Bundle ID: $BUNDLE_ID
+EOF
+
+echo "✅ $APP_NAME.app created successfully!"
+echo "📂 Location: $APP_BUNDLE"
+echo "📱 Launch with: open \"$APP_BUNDLE\""
 echo "🔧 The app should now appear in System Settings > Accessibility"
+echo "📋 Build info: $DIST_DIR/build-info.txt"

--- a/scratchpads/issue-30-build-distribution-structure.md
+++ b/scratchpads/issue-30-build-distribution-structure.md
@@ -1,0 +1,86 @@
+# Issue #30: Build Distribution Output Structure
+
+**Link:** [GitHub Issue #30](https://github.com/jsonify/clickit/issues/30)
+
+## Analysis
+
+### Current State
+- ✅ `.build/` directory already in `.gitignore`
+- ✅ `build_app.sh` script exists for creating `.app` bundles
+- ❌ Build script hardcoded to x86_64 architecture only
+- ❌ No universal binary support
+- ❌ Build artifacts mixed with development
+- ❌ No structured `dist/` directory organization
+
+### Key Issues Identified
+
+1. **Architecture Limitation**: `build_app.sh` hardcodes x86_64 path:
+   ```bash
+   cp .build/x86_64-apple-macosx/release/ClickIt ClickIt.app/Contents/MacOS/
+   ```
+
+2. **No Universal Binary**: Missing Apple Silicon support
+
+3. **Build Output Location**: App bundle created in project root instead of dedicated distribution directory
+
+4. **No Development vs Distribution Separation**: Single build script for all purposes
+
+## Implementation Plan
+
+### Phase 1: Universal Binary Support
+- Update `build_app.sh` to detect architecture automatically
+- Add universal binary creation using `lipo` command
+- Test on both Intel and Apple Silicon
+
+### Phase 2: Distribution Structure
+- Create `dist/` directory for distribution artifacts
+- Separate development builds from distribution builds
+- Implement clean build process
+
+### Phase 3: Build Script Enhancement
+- Create multiple build modes (dev, release, universal)
+- Add proper error handling and validation
+- Implement clean/rebuild functionality
+
+### Phase 4: Documentation
+- Update README with distribution build instructions
+- Document universal binary process
+- Add CI/CD preparation notes
+
+## Technical Approach
+
+### Universal Binary Strategy
+```bash
+# Build for both architectures
+swift build -c release --arch x86_64
+swift build -c release --arch arm64
+
+# Create universal binary
+lipo -create -output ClickIt \
+  .build/x86_64-apple-macosx/release/ClickIt \
+  .build/arm64-apple-macosx/release/ClickIt
+```
+
+### Distribution Structure
+```
+dist/
+├── ClickIt.app/           # Final app bundle
+├── ClickIt-universal      # Universal binary
+├── ClickIt-x86_64         # Intel binary
+├── ClickIt-arm64          # Apple Silicon binary
+└── metadata/              # Build metadata
+```
+
+## Acceptance Criteria Verification
+- [ ] Build artifacts no longer output to project root ✅ (already in .gitignore)
+- [ ] Clear documentation for distributable builds
+- [ ] Proper macOS app bundle structure ✅ (script exists, needs enhancement)
+- [ ] Universal binary support (Intel x64 + Apple Silicon)
+- [ ] Maintains existing development workflow
+
+## Next Steps
+1. Enhance build script for universal binary support
+2. Create distribution directory structure
+3. Add build mode selection
+4. Test on both architectures
+5. Update documentation


### PR DESCRIPTION
The build system has been improved to support universal binaries for both Intel x64 and Apple Silicon architectures. A structured `dist/` directory has been implemented for organized build outputs, separating development and distribution builds. The `build_app.sh` script has been enhanced to automatically detect architectures, create app bundles, and generate build metadata. Comprehensive documentation has been added to the README for the new build process.

Closes #30.