### PR TITLE
Fix/app-launch-crashes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,67 @@ The project is in early development with basic structure established:
 
 **Preset System**: Store configurations in UserDefaults with custom naming support
 
+## Known Issues & Solutions
+
+### Application Crashes and Debugging (July 2025)
+
+During development of Issue #8 (Visual Feedback System), several critical stability issues were discovered and resolved:
+
+#### 🔐 **Code Signing Issues**
+**Problem**: App crashes after running `./scripts/sign-app.sh`
+- **Root Cause**: Expired Apple Development certificate (expired June 2021)
+- **Secondary Issue**: Original signing script ran `swift build` which overwrote universal release binary with debug binary
+- **Solution**: 
+  - Updated to use valid certificate: `Apple Development: jrueckert@costco.com (826L9Z2Y4X)` (expires May 2026)
+  - Fixed signing script to preserve universal binary (removed `swift build` command)
+  - Check certificate validity: `security find-certificate -c "CERT_NAME" -p | openssl x509 -text -noout | grep "Not After"`
+
+#### ⚡ **Permission System Crashes**
+**Problem**: App crashes when Accessibility permission is toggled ON in System Settings
+- **Root Cause**: Concurrency issues in permission monitoring system
+- **Specific Issues**:
+  - `PermissionManager.updatePermissionStatus()` used `DispatchQueue.main.async` despite being on `@MainActor`
+  - `PermissionStatusChecker` timers used `Task { @MainActor in ... }` creating race conditions
+- **Solution**:
+  - Removed redundant `DispatchQueue.main.async` in `updatePermissionStatus()`
+  - Changed Timer callbacks to use `DispatchQueue.main.async` instead of `Task { @MainActor }`
+  - Fixed in: `PermissionManager.swift` lines 32-40, `PermissionStatusChecker.swift` lines 30-34
+
+#### 📡 **Permission Detection Not Working**
+**Problem**: App doesn't detect when permissions are granted/revoked
+- **Root Cause**: Permission monitoring not started automatically
+- **Solution**: Added `permissionManager.startPermissionMonitoring()` in ContentView.onAppear
+
+#### 🧪 **Debugging Methodology**
+**Approach**: Component isolation testing
+1. Created minimal ContentView with only basic permission status
+2. Added components incrementally: ClickPointSelector → ConfigurationPanel → Development Tools
+3. Tested each addition for crash behavior when toggling permissions
+4. **Result**: All UI components were safe; crashes were from underlying permission system issues
+
+### Build & Deployment Pipeline
+
+**Correct Workflow**:
+```bash
+# 1. Build universal release binary
+./build_app.sh
+
+# 2. Sign with valid certificate (preserves binary)
+./scripts/sign-app.sh
+
+# 3. Launch for testing
+open dist/ClickIt.app
+```
+
+**Critical**: Always verify certificate validity before signing. Use `scripts/skip-signing.sh` if only self-signed certificate is needed.
+
+### Permission System Requirements
+
+**Essential for Stability**:
+1. **Start monitoring**: Call `permissionManager.startPermissionMonitoring()` in app initialization
+2. **Avoid concurrency conflicts**: Use proper `@MainActor` isolation without redundant dispatch
+3. **Test permission changes**: Always test toggling permissions ON/OFF during development
+
 ## Documentation References
 
 - Full product requirements: `docs/clickit_autoclicker_prd.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ During development of Issue #8 (Visual Feedback System), several critical stabil
 - **Root Cause**: Expired Apple Development certificate (expired June 2021)
 - **Secondary Issue**: Original signing script ran `swift build` which overwrote universal release binary with debug binary
 - **Solution**: 
-  - Updated to use valid certificate: `Apple Development: jrueckert@costco.com (826L9Z2Y4X)` (expires May 2026)
+  - Updated to use valid certificate: `Apple Development: [DEVELOPER_NAME] ([TEAM_ID])` (certificate must be valid)
   - Fixed signing script to preserve universal binary (removed `swift build` command)
   - Check certificate validity: `security find-certificate -c "CERT_NAME" -p | openssl x509 -text -noout | grep "Not After"`
 
@@ -170,10 +170,22 @@ During development of Issue #8 (Visual Feedback System), several critical stabil
 ./build_app.sh
 
 # 2. Sign with valid certificate (preserves binary)
-./scripts/sign-app.sh
+CODE_SIGN_IDENTITY="Apple Development: Your Name (TEAM_ID)" ./scripts/sign-app.sh
 
 # 3. Launch for testing
 open dist/ClickIt.app
+```
+
+**Certificate Setup**:
+```bash
+# List available certificates
+security find-identity -v -p codesigning
+
+# Set certificate for session
+export CODE_SIGN_IDENTITY="Apple Development: Your Name (TEAM_ID)"
+
+# Or add to shell profile for persistence
+echo 'export CODE_SIGN_IDENTITY="Apple Development: Your Name (TEAM_ID)"' >> ~/.zshrc
 ```
 
 **Critical**: Always verify certificate validity before signing. Use `scripts/skip-signing.sh` if only self-signed certificate is needed.

--- a/Sources/ClickIt/Core/Models/ClickSettings.swift
+++ b/Sources/ClickIt/Core/Models/ClickSettings.swift
@@ -12,7 +12,11 @@ class ClickSettings: ObservableObject {
     @Published var clickIntervalMs: Double = 1000.0 {
         didSet {
             // Ensure interval is within valid range
-            clickIntervalMs = max(AppConstants.minClickInterval * 1000, min(AppConstants.maxClickInterval * 1000, clickIntervalMs))
+            let clampedValue = max(AppConstants.minClickInterval * 1000, min(AppConstants.maxClickInterval * 1000, clickIntervalMs))
+            if clickIntervalMs != clampedValue {
+                clickIntervalMs = clampedValue
+                return // saveSettings() will be called by the recursive didSet
+            }
             saveSettings()
         }
     }
@@ -34,7 +38,11 @@ class ClickSettings: ObservableObject {
     /// Duration value in seconds (when duration mode is not unlimited)
     @Published var durationSeconds: Double = 60.0 {
         didSet {
-            durationSeconds = max(1.0, min(86400.0, durationSeconds)) // 1 second to 24 hours
+            let clampedValue = max(1.0, min(86400.0, durationSeconds)) // 1 second to 24 hours
+            if durationSeconds != clampedValue {
+                durationSeconds = clampedValue
+                return // saveSettings() will be called by the recursive didSet
+            }
             saveSettings()
         }
     }
@@ -42,7 +50,11 @@ class ClickSettings: ObservableObject {
     /// Maximum number of clicks (when duration mode is click count)
     @Published var maxClicks: Int = 100 {
         didSet {
-            maxClicks = max(1, min(10000, maxClicks)) // 1 to 10,000 clicks
+            let clampedValue = max(1, min(10000, maxClicks)) // 1 to 10,000 clicks
+            if maxClicks != clampedValue {
+                maxClicks = clampedValue
+                return // saveSettings() will be called by the recursive didSet
+            }
             saveSettings()
         }
     }
@@ -71,7 +83,11 @@ class ClickSettings: ObservableObject {
     /// Location randomization variance in pixels
     @Published var locationVariance: Double = 5.0 {
         didSet {
-            locationVariance = max(0.0, min(100.0, locationVariance)) // 0 to 100 pixels
+            let clampedValue = max(0.0, min(100.0, locationVariance)) // 0 to 100 pixels
+            if locationVariance != clampedValue {
+                locationVariance = clampedValue
+                return // saveSettings() will be called by the recursive didSet
+            }
             saveSettings()
         }
     }

--- a/Sources/ClickIt/Core/Permissions/PermissionManager.swift
+++ b/Sources/ClickIt/Core/Permissions/PermissionManager.swift
@@ -33,11 +33,10 @@ class PermissionManager: ObservableObject {
         let accessibility = checkAccessibilityPermission()
         let screenRecording = checkScreenRecordingPermission()
         
-        DispatchQueue.main.async { [weak self] in
-            self?.accessibilityPermissionGranted = accessibility
-            self?.screenRecordingPermissionGranted = screenRecording
-            self?.allPermissionsGranted = accessibility && screenRecording
-        }
+        // We're already on MainActor, no need for DispatchQueue.main.async
+        accessibilityPermissionGranted = accessibility
+        screenRecordingPermissionGranted = screenRecording
+        allPermissionsGranted = accessibility && screenRecording
     }
     
     // MARK: - Permission Requesting
@@ -110,7 +109,8 @@ class PermissionManager: ObservableObject {
     
     func startPermissionMonitoring() {
         Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            Task { @MainActor in
+            // Safer permission update without extra Task wrapping
+            DispatchQueue.main.async {
                 self?.updatePermissionStatus()
             }
         }

--- a/Sources/ClickIt/Core/Permissions/PermissionStatusChecker.swift
+++ b/Sources/ClickIt/Core/Permissions/PermissionStatusChecker.swift
@@ -28,7 +28,7 @@ class PermissionStatusChecker: ObservableObject {
         
         // Set up periodic monitoring
         monitoringTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            Task { @MainActor in
+            DispatchQueue.main.async {
                 self?.checkPermissionStatus()
             }
         }

--- a/Sources/ClickIt/UI/Views/ContentView.swift
+++ b/Sources/ClickIt/UI/Views/ContentView.swift
@@ -120,6 +120,8 @@ struct ContentView: View {
         .background(Color(NSColor.windowBackgroundColor))
         .onAppear {
             permissionManager.updatePermissionStatus()
+            // Start monitoring for permission changes
+            permissionManager.startPermissionMonitoring()
         }
         .sheet(isPresented: $showingPermissionSetup) {
             PermissionRequestView()

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,33 @@
+# Build Scripts
+
+## Code Signing
+
+The `sign-app.sh` script requires a code signing identity to be specified via environment variable for security reasons.
+
+### Setup
+
+1. List available certificates:
+```bash
+security find-identity -v -p codesigning
+```
+
+2. Set the environment variable:
+```bash
+export CODE_SIGN_IDENTITY="Apple Development: Your Name (TEAM_ID)"
+```
+
+3. Run the signing script:
+```bash
+./scripts/sign-app.sh
+```
+
+### Alternative Usage
+
+You can also provide the identity inline:
+```bash
+CODE_SIGN_IDENTITY="Apple Development: Your Name (TEAM_ID)" ./scripts/sign-app.sh
+```
+
+### Security Note
+
+Never commit code signing identities to version control. The environment variable approach ensures sensitive certificate information stays local to your development environment.

--- a/scripts/sign-app.sh
+++ b/scripts/sign-app.sh
@@ -17,8 +17,8 @@ if [ ! -d "dist/ClickIt.app" ]; then
     exit 1
 fi
 
-# Sign with development certificate
-codesign --force --sign "Apple Development: Jason Rueckert (5K35266D72)" --timestamp dist/ClickIt.app
+# Sign with development certificate (trying the other cert)
+codesign --force --sign "Apple Development: jrueckert@costco.com (826L9Z2Y4X)" --timestamp dist/ClickIt.app
 
 # Verify signing
 echo "✅ Verifying signature..."

--- a/scripts/sign-app.sh
+++ b/scripts/sign-app.sh
@@ -14,8 +14,16 @@ if [ ! -d "dist/ClickIt.app" ]; then
     exit 1
 fi
 
-# Sign with development certificate (valid certificate)
-codesign --force --sign "Apple Development: jrueckert@costco.com (826L9Z2Y4X)" --timestamp dist/ClickIt.app
+# Sign with development certificate
+if [ -z "$CODE_SIGN_IDENTITY" ]; then
+    echo "❌ CODE_SIGN_IDENTITY environment variable not set"
+    echo "   Set it with: export CODE_SIGN_IDENTITY=\"Apple Development: Your Name (TEAM_ID)\""
+    echo "   Or run: CODE_SIGN_IDENTITY=\"Apple Development: Your Name (TEAM_ID)\" ./scripts/sign-app.sh"
+    exit 1
+fi
+
+echo "🔐 Using certificate: $CODE_SIGN_IDENTITY"
+codesign --force --sign "$CODE_SIGN_IDENTITY" --timestamp dist/ClickIt.app
 
 # Verify signing
 echo "✅ Verifying signature..."

--- a/scripts/sign-app.sh
+++ b/scripts/sign-app.sh
@@ -7,9 +7,6 @@ set -e
 
 echo "🔐 Signing ClickIt app..."
 
-# Build the app first
-swift build
-
 # Copy to app bundle (if not already done by build script)
 if [ ! -d "dist/ClickIt.app" ]; then
     echo "❌ App bundle not found at dist/ClickIt.app"
@@ -17,7 +14,7 @@ if [ ! -d "dist/ClickIt.app" ]; then
     exit 1
 fi
 
-# Sign with development certificate (trying the other cert)
+# Sign with development certificate (valid certificate)
 codesign --force --sign "Apple Development: jrueckert@costco.com (826L9Z2Y4X)" --timestamp dist/ClickIt.app
 
 # Verify signing

--- a/scripts/skip-signing.sh
+++ b/scripts/skip-signing.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Skip additional signing - app already works with self-signed certificate
+# Usage: ./scripts/skip-signing.sh
+
+echo "🔐 Skipping additional code signing..."
+echo "✅ App is already signed with ClickIt Developer Certificate"
+echo "📱 Launch with: open dist/ClickIt.app"
+
+# Verify current signature
+echo "📋 Current signature:"
+codesign -dv dist/ClickIt.app
+
+echo "🎉 Ready to use!"


### PR DESCRIPTION
- Fix infinite recursion in ClickSettings didSet observers that caused stack overflow crashes
- Add value comparison checks to prevent recursive property setting
- Fix signing script that was overwriting release binary with debug version
- Add missing permission monitoring startup to prevent detection failures
- Remove expired certificate and clean up backup files

Resolves segmentation fault on app launch and ensures stable app signing process.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>